### PR TITLE
FEATURE: make the permissions for viewing better navigator separate from...

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -8,3 +8,6 @@ LeftAndMain:
 ContentController:
   extensions:
     - BetterNavigator
+Permission:
+  extensions:
+    - BetterNavigator_Permissions

--- a/templates/BetterNavigator.ss
+++ b/templates/BetterNavigator.ss
@@ -31,8 +31,9 @@
 						<span class="bn-disabled"><span class="bn-icon-view"></span>Deleted from draft site</span>
 					<% end_if %>
 				<% end_if %>
-				<a href="$CMSLink.Link" target="_blank"><span class="bn-icon-edit"></span>Edit in CMS</a>
-				
+				<% if $CanEdit %>
+					<a href="$CMSLink.Link" target="_blank"><span class="bn-icon-edit"></span>Edit in CMS</a>
+				<% end_if %>
 				<% if $Member %>
 					<a href="Security/logout?BackURL=$Link"><span class="bn-icon-user"></span>Log out<% if $Member.FirstName %><span class="light"> ($Member.FirstName)</span><% end_if %></a>
 				<% else %>


### PR DESCRIPTION
... the CMS permissions

We have the situation where we sometimes do not give access to the "Pages" section for non administrative users, even though they have access to the CMS. This change allows us to better manage who can view BetterNavigator on the front end.

An alternative to this would be removing the "edit page" button if the user didn't have another set of permissions, but for our use case this seemed the simplest change.
