### PR TITLE
Added support for a different unique field of Member in developer config

### DIFF
--- a/code/BetterNavigator.php
+++ b/code/BetterNavigator.php
@@ -54,7 +54,8 @@ class BetterNavigator extends DataExtension {
             // Is the logged in member nominated as a developer?
             $member = Member::currentUser();
             $devs = Config::inst()->get('BetterNavigator', 'developers');
-            $isDeveloper = $member && is_array($devs) ? in_array($member->Email, $devs) : false;
+            $identifierField = Member::config()->unique_identifier_field;
+            $isDeveloper = $member && is_array($devs) ? in_array($member->{$identifierField}, $devs) : false;
 
             // Add other data for template
             $backURL = '?BackURL=' . urlencode($this->owner->Link());


### PR DESCRIPTION
After this change the BetterNavigator.developers config will respect Member.unique_identifier_field. E.g. If there is a website using a Username field for login (instead of E-Mail), the config will expect usernames instead of emails to identify admins. As this change might break existing code, it might be better for a new major version (according to semver)?