### PR TITLE
Add config option to use absolute links inside the widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Download, place the folder in your project root, rename it to 'betternavigator' 
 Just place **$BetterNavigator** somewhere in your template(s). If your website uses caching, make sure BetterNavigator's output is excluded.
 
 **Access developer tools on a live website**
+
 You can mark certain CMS users as developers in your site's config, so they can access developer tools when logged in. Example YAML:
 
 ```
@@ -39,6 +40,17 @@ You can mark certain CMS users as developers in your site's config, so they can 
     developers:
       - 'dev@yoursite.com'
       - 'otherdev@yoursite.com'
+```
+
+**Use absolute links**
+
+Some sites may opt to not use base tag in the page head (e.g. it could be problematic with hash links within a page).
+In that case you can use this YAML settings to force output of absolute links always starting with a slash.
+
+```
+  BetterNavigator:
+    developers:
+      useAbsoluteLinks: true
 ```
 
 ##Customisation

--- a/code/BetterNavigator.php
+++ b/code/BetterNavigator.php
@@ -17,6 +17,18 @@ class BetterNavigator extends DataExtension {
     private static $developers;
 
     /**
+     * Force use of absolute links starting with a slash for sites not using base tag
+     * Example YAML:
+     *
+     * BetterNavigator:
+     *   useAbsoluteLinks: true
+     *
+     * @config
+     * @var boolean
+     */
+    private static $useAbsoluteLinks = false;
+
+    /**
      * Provides a front-end utility menu with administrative functions and developer tools
      * Relies on SilverStripeNavigator
      *
@@ -30,6 +42,10 @@ class BetterNavigator extends DataExtension {
         $isDev = Director::isDev();
         $canViewDraft = (Permission::check('VIEW_DRAFT_CONTENT') || Permission::check('CMS_ACCESS_CMSMain'));
         if($isDev || $canViewDraft) {
+            // use absolute links
+            $useAbsLinks = Config::inst()->get('BetterNavigator', 'useAbsoluteLinks');
+            $linkPrefix = ($useAbsLinks ? '/' : '');
+
             // Get SilverStripeNavigator links & stage info (CMS/Stage/Live/Archive)
             $nav = array();
             $viewing = '';
@@ -39,8 +55,8 @@ class BetterNavigator extends DataExtension {
                 $name = $item->getName();
                 $active = $item->isActive();
                 $nav[$name] = array(
-                    'Link' => $item->getLink(),
-                    'Active' => $active
+                    'Link' => (($name == 'CMSLink') ? $linkPrefix : '') . $item->getLink(),
+                    'Active' => $active,
                 );
                 if ($active) {
                     if ($name == 'LiveLink') $viewing = 'Live';
@@ -54,8 +70,7 @@ class BetterNavigator extends DataExtension {
             // Is the logged in member nominated as a developer?
             $member = Member::currentUser();
             $devs = Config::inst()->get('BetterNavigator', 'developers');
-            $identifierField = Member::config()->unique_identifier_field;
-            $isDeveloper = $member && is_array($devs) ? in_array($member->{$identifierField}, $devs) : false;
+            $isDeveloper = $member && is_array($devs) ? in_array($member->Email, $devs) : false;
 
             // Add other data for template
             $backURL = '?BackURL=' . urlencode($this->owner->Link());
@@ -63,11 +78,12 @@ class BetterNavigator extends DataExtension {
                 'Member' => $member,
                 'Stage' => Versioned::current_stage(),
                 'Viewing' => $viewing, // What we're viewing doesn't necessarily align with the active Stage
-                'LoginLink' => Config::inst()->get('Security', 'login_url') . $backURL,
-                'LogoutLink' => 'Security/logout' . $backURL,
+                'LoginLink' => $linkPrefix . Config::inst()->get('Security', 'login_url') . $backURL,
+                'LogoutLink' => $linkPrefix . 'Security/logout' . $backURL,
                 'EditLink' => $editLink,
                 'Mode' => Director::get_environment_type(),
-                'IsDeveloper' => $isDeveloper
+                'IsDeveloper' => $isDeveloper,
+                'LinkPrefix' => $linkPrefix,
             ));
 
             // Merge with page data, send to template and render

--- a/templates/BetterNavigator.ss
+++ b/templates/BetterNavigator.ss
@@ -60,8 +60,10 @@
                 <% end_if %>
 
                 <a href="$Link?flush=1" title="Flush templates and manifest, and regenerate images for this page (behaviour varies by Framework version)"><span class="bn-icon-flush"></span>Flush caches</a>
-                <a href="dev/build/?flush=1" target="_blank" title="Build database and flush caches (excludes template caches pre SS-3.1.7)"><span class="bn-icon-db"></span>Build database</a>
-                <a href="dev" target="_blank"><span class="bn-icon-tools"></span>Dev menu</a>
+                <% with $BetterNavigator %>
+                <a href="{$LinkPrefix}dev/build/?flush=1" target="_blank" title="Build database and flush caches (excludes template caches pre SS-3.1.7)"><span class="bn-icon-db"></span>Build database</a>
+                <a href="{$LinkPrefix}dev" target="_blank"><span class="bn-icon-tools"></span>Dev menu</a>
+                <% end_with %>
 
             </div>
 


### PR DESCRIPTION
Non-BC change to add an option to specify whether absolute links should be used inside the widget.

Some sites don't use `<base>` tag, in which case all relative links inside the widget stop working.