### PR TITLE
Only hook to DOMContentLoaded while loading - SS3

### DIFF
--- a/javascript/betternavigator.js
+++ b/javascript/betternavigator.js
@@ -32,13 +32,13 @@ function initialiseBetterNavigator() {
     }
 }
 
-if (document.addEventListener) {
+if (document.addEventListener && document.readyState === 'loading') {
     document.addEventListener("DOMContentLoaded", function () {
-        //wait til DOM is ready
+        // wait til DOM finishes loading
         initialiseBetterNavigator();
     });
 } else {
-    //This is the case for IE8 and below
-    //initialise straight away - fine if script is loaded after BN dom element
+    // This is the case for IE8 and below OR already loaded document (e.g. when using async)
+    // initialise straight away - fine if script is loaded after BN dom element
     initialiseBetterNavigator();
 }


### PR DESCRIPTION
If the browser supports DOMContentLoaded event, the initialisation routine listener should be added when the event hasn't occured yet (i.e. the document is still loading).

When JS files are loaded asynchronously, the complete event has already been fired and BN doesn't get initialised.

Note: Possible states for the document.readyState that might be relevant to this are 'loading', 'interactive' and 'complete'. Relevant discussion: https://stackoverflow.com/a/9237129/2303501