### PR TITLE
NEW: Auto-injection into template

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ The navigator is auto-injected into your template, and no code changes are neede
 
 If your website uses caching, make sure BetterNavigator's output is excluded.
 
+## Disabling the navigator
+
+You can disable the navigator using your own custom logic by defining a `showBetterNavigator(): bool`
+method in any controller with the extension applied.
+
+```php
+public function showBetterNavigator(): bool
+{
+    // A user-defined setting
+    return $this->ShowDebugTools;
+}
+```
 **Access developer tools on a live website**
 You can mark certain CMS users as developers in your site's config, so they can access developer tools when logged in. Example YAML:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can disable the navigator using your own custom logic by defining a `showBet
 method in any controller with the extension applied.
 
 ```php
-public function showBetterNavigator(): bool
+public function showBetterNavigator()
 {
     // A user-defined setting
     return $this->ShowDebugTools;
@@ -68,10 +68,6 @@ If you want to add some content (new buttons for instance) to BetterNavigator, j
 All content, scripts and CSS are loaded via the BetterNavigator.ss template, so you can completely customise BetterNavigator's front-end code by copying or creating your own BetterNavigator.ss template.
 
 The BetterNavigator.ss template's scope is set to the page that is being viewed, so any methods available in your page controller will be available in the BetterNavigator.ss template. This should allow you to add custom links by page type and introduce complex logic if you want to.
-
-## Known issues
-
- * Probably won't work in IE8 or lower.
 
 ## Bonus: better debugging tools
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module is intended to replicate and expand upon the functionality provided 
 
 ## Requirements
 
-SilverStripe 4.2 (3.1+ through previous releases)
+SilverStripe 4.3 (3.1+ through previous releases)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module is intended to replicate and expand upon the functionality provided 
 
 ## Requirements
 
-SilverStripe 4.0 (3.1+ through previous releases)
+SilverStripe 4.2 (3.1+ through previous releases)
 
 ## Installation
 
@@ -29,7 +29,9 @@ Download, place the folder in your project root, rename it to 'betternavigator' 
 
 ## How to use
 
-Just place **$BetterNavigator** somewhere in your template(s). If your website uses caching, make sure BetterNavigator's output is excluded.
+The navigator is auto-injected into your template, and no code changes are needed.
+
+If your website uses caching, make sure BetterNavigator's output is excluded.
 
 **Access developer tools on a live website**
 You can mark certain CMS users as developers in your site's config, so they can access developer tools when logged in. Example YAML:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": ">= 4.2"
+        "silverstripe/framework": "^4.2"
     },
     "extra": {
         "installer-name": "betternavigator",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.0"
+        "silverstripe/framework": ">= 4.2"
     },
     "extra": {
         "installer-name": "betternavigator",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.2"
+        "silverstripe/framework": "^4.3"
     },
     "extra": {
         "installer-name": "betternavigator",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.3"
+        "silverstripe/framework": "^4.0"
     },
     "extra": {
         "installer-name": "betternavigator",

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -42,9 +42,10 @@ class BetterNavigatorExtension extends DataExtension
      */
     protected function generateNavigator()
     {
-
         // Make sure this is a page
-        if (!$this->isAPage()) return false;
+        if (!$this->isAPage() || !$this->owner->showBetterNavigator()) {
+            return false;
+        }
 
         // Only show navigator to appropriate users
         $isDev = Director::isDev();
@@ -94,10 +95,11 @@ class BetterNavigatorExtension extends DataExtension
             ]);
 
             // Merge with page data, send to template and render
-            $bNData = new ArrayData($bNData);
-            $page = $this->owner->customise(['BetterNavigator' => $bNData]);
-            return $page->renderWith('BetterNavigator\\BetterNavigator');
+            $navigator = new ArrayData($bNData);
+
+            return $navigator->renderWith('BetterNavigator\\BetterNavigator');
         }
+
         return false;
     }
 
@@ -136,7 +138,16 @@ class BetterNavigatorExtension extends DataExtension
         $result->setValue($html);
 
         return $result;
-    }    
+    }
+
+    /**
+     * Override on a per-controller basis to add custom logic
+     * @return bool
+     */
+    public function showBetterNavigator(): bool
+    {
+        return true;
+    }
 
     /**
      * @return boolean

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -16,102 +16,25 @@ use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\ArrayData;
 use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\View\Requirements;
 
 class BetterNavigatorExtension extends DataExtension
 {
 
     /**
-     * @var string
+     * @var bool|null
      */
-    private $navigatorHTML;
+    private $shouldDisplay = null;
 
     /**
-     * Noop, pseudo backward compatability only
-     * @return DBHTMLText
-     */
-    public function BetterNavigator()
-    {
-    	return DBField::create_field('HTMLText', '');
-    }
-
-    /**
-     * Provides a front-end utility menu with administrative functions and developer tools
-     * Relies on SilverStripeNavigator
-     *
-     * @return DBHTMLText|false
-     */
-    protected function generateNavigator()
-    {
-        // Make sure this is a page
-        if (!$this->isAPage() || !$this->owner->showBetterNavigator()) {
-            return false;
-        }
-
-        // Only show navigator to appropriate users
-        $isDev = Director::isDev();
-        $canViewDraft = (Permission::check('VIEW_DRAFT_CONTENT') || Permission::check('CMS_ACCESS_CMSMain'));
-        if ($isDev || $canViewDraft) {
-            // Get SilverStripeNavigator links & stage info (CMS/Stage/Live/Archive)
-            $nav = [];
-            $viewing = '';
-            $navigator = SilverStripeNavigator::create($this->owner->dataRecord);
-            $items = $navigator->getItems();
-            foreach ($items as $item) {
-                $name = $item->getName();
-                $active = $item->isActive();
-                $nav[$name] = [
-                    'Link' => $item->getLink(),
-                    'Active' => $active
-                ];
-                if ($active) {
-                    if ($name == 'LiveLink') $viewing = 'Live';
-                    if ($name == 'StageLink') $viewing = 'Draft';
-                    if ($name == 'ArchiveLink') $viewing = 'Archived';
-                }
-            }
-            // Only show edit link if user has permission to edit this page
-            $editLink = array_key_exists('CMSLink', $nav)
-                && ($isDev || $this->owner->dataRecord->canEdit() && Permission::check('CMS_ACCESS_CMSMain'))
-                ? $nav['CMSLink']['Link'] : false;
-
-            // Is the logged in member nominated as a developer?
-            $member = Member::currentUser();
-            $devs = Config::inst()->get('BetterNavigator', 'developers');
-            $identifierField = Member::config()->unique_identifier_field;
-            $isDeveloper = $member && is_array($devs) ? in_array($member->{$identifierField}, $devs) : false;
-
-            // Add other data for template
-            $backURL = '?BackURL=' . urlencode($this->owner->Link());
-            $bNData = array_merge($nav, [
-                'Member' => $member,
-                'Stage' => Versioned::get_stage(),
-                'Viewing' => $viewing, // What we're viewing doesn't necessarily align with the active Stage
-                'LoginLink' => Controller::join_links(Director::absoluteBaseURL(), Security::config()->login_url, $backURL),
-                'LogoutLink' => Controller::join_links(Director::absoluteBaseURL() . Security::config()->logout_url, $backURL),
-                'LogoutForm' => LogoutForm::create($this->owner)->setName('BetterNavigatorLogoutForm'),
-                'EditLink' => $editLink,
-                'Mode' => Director::get_environment_type(),
-                'IsDeveloper' => $isDeveloper
-            ]);
-
-            // Merge with page data, send to template and render
-            $navigator = new ArrayData($bNData);
-
-            return $navigator->renderWith('BetterNavigator\\BetterNavigator');
-        }
-
-        return false;
-    }
-
-    /**
-     * Prerender HTML to ensure that <% require %> gets loaded
+     * Load requirements in before final render. When the next extension point is called, it's too late.
      * @return void
      */
     public function beforeCallActionHandler(): void
     {
-        $navigator = $this->generateNavigator();
-        if ($navigator) {
-            $this->navigatorHTML = $navigator->getValue();
+        if ($this->shouldDisplay()) {
+            Requirements::javascript('jonom/silverstripe-betternavigator: javascript/betternavigator.js');
+            Requirements::css('jonom/silverstripe-betternavigator: css/betternavigator.css');
         }
     }
 
@@ -123,16 +46,17 @@ class BetterNavigatorExtension extends DataExtension
      */
     public function afterCallActionHandler($request, $action, $result): DBHTMLText
     {
-        if (!$this->navigatorHTML) {
+        if (!$this->shouldDisplay()) {
             return $result;
         }
 
         $html = $result->getValue();
+        $navigatorHTML = $this->generateNavigator()->getValue();
 
         // Inject the NavigatorHTML before the closing </body> tag
         $html = preg_replace(
             '/(<\/body[^>]*>)/i',
-            $this->navigatorHTML . '\\1',
+            $navigatorHTML . '\\1',
             $html
         );
         $result->setValue($html);
@@ -150,9 +74,90 @@ class BetterNavigatorExtension extends DataExtension
     }
 
     /**
+     * Provides a front-end utility menu with administrative functions and developer tools
+     * Relies on SilverStripeNavigator
+     *
+     * @return DBHTMLText
+     */
+    private function generateNavigator(): DBHTMLText
+    {
+        // Get SilverStripeNavigator links & stage info (CMS/Stage/Live/Archive)
+        $nav = [];
+        $viewing = '';
+        $navigator = SilverStripeNavigator::create($this->owner->dataRecord);
+        $isDev = Director::isDev();
+
+        $items = $navigator->getItems();
+        foreach ($items as $item) {
+            $name = $item->getName();
+            $active = $item->isActive();
+            $nav[$name] = [
+                'Link' => $item->getLink(),
+                'Active' => $active
+            ];
+            if ($active) {
+                if ($name == 'LiveLink') $viewing = 'Live';
+                if ($name == 'StageLink') $viewing = 'Draft';
+                if ($name == 'ArchiveLink') $viewing = 'Archived';
+            }
+        }
+        // Only show edit link if user has permission to edit this page
+        $editLink = array_key_exists('CMSLink', $nav)
+        && ($isDev || $this->owner->dataRecord->canEdit() && Permission::check('CMS_ACCESS_CMSMain'))
+            ? $nav['CMSLink']['Link'] : false;
+
+        // Is the logged in member nominated as a developer?
+        $member = Member::currentUser();
+        $devs = Config::inst()->get('BetterNavigator', 'developers');
+        $identifierField = Member::config()->unique_identifier_field;
+        $isDeveloper = $member && is_array($devs) ? in_array($member->{$identifierField}, $devs) : false;
+
+        // Add other data for template
+        $backURL = '?BackURL=' . urlencode($this->owner->Link());
+        $bNData = array_merge($nav, [
+            'Member' => $member,
+            'Stage' => Versioned::get_stage(),
+            'Viewing' => $viewing, // What we're viewing doesn't necessarily align with the active Stage
+            'LoginLink' => Controller::join_links(Director::absoluteBaseURL(), Security::config()->login_url, $backURL),
+            'LogoutLink' => Controller::join_links(Director::absoluteBaseURL() . Security::config()->logout_url, $backURL),
+            'LogoutForm' => LogoutForm::create($this->owner)->setName('BetterNavigatorLogoutForm'),
+            'EditLink' => $editLink,
+            'Mode' => Director::get_environment_type(),
+            'IsDeveloper' => $isDeveloper
+        ]);
+
+        // Merge with page data, send to template and render
+        $navigator = new ArrayData($bNData);
+
+        return $this->owner->customise($navigator)->renderWith('BetterNavigator\\BetterNavigator');
+    }
+
+    /**
+     * Internally compute and cache weather the navigator should display
+     * @return bool
+     */
+    private function shouldDisplay(): bool
+    {
+        if ($this->shouldDisplay !== null) {
+            return $this->shouldDisplay;
+        }
+
+        // Make sure this is a page
+        if (!$this->isAPage() || !$this->owner->showBetterNavigator()) {
+            return $this->shouldDisplay = false;
+        }
+
+        // Only show navigator to appropriate users
+        $isDev = Director::isDev();
+        $canViewDraft = (Permission::check('VIEW_DRAFT_CONTENT') || Permission::check('CMS_ACCESS_CMSMain'));
+
+        return $this->shouldDisplay = ($isDev || $canViewDraft);
+    }
+
+    /**
      * @return boolean
      */
-    protected function isAPage()
+    private function isAPage(): bool
     {
         return $this->owner
             && $this->owner->dataRecord

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -30,7 +30,7 @@ class BetterNavigatorExtension extends DataExtension
      * Load requirements in before final render. When the next extension point is called, it's too late.
      * @return void
      */
-    public function beforeCallActionHandler(): void
+    public function beforeCallActionHandler()
     {
         if ($this->shouldDisplay()) {
             Requirements::javascript('jonom/silverstripe-betternavigator: javascript/betternavigator.js');
@@ -44,7 +44,7 @@ class BetterNavigatorExtension extends DataExtension
      * @param DBHTMLText $result
      * @return DBHTMLText
      */
-    public function afterCallActionHandler($request, $action, $result): DBHTMLText
+    public function afterCallActionHandler($request, $action, $result)
     {
         if (!$this->shouldDisplay()) {
             return $result;
@@ -68,7 +68,7 @@ class BetterNavigatorExtension extends DataExtension
      * Override on a per-controller basis to add custom logic
      * @return bool
      */
-    public function showBetterNavigator(): bool
+    public function showBetterNavigator()
     {
         return true;
     }
@@ -79,7 +79,7 @@ class BetterNavigatorExtension extends DataExtension
      *
      * @return DBHTMLText
      */
-    private function generateNavigator(): DBHTMLText
+    private function generateNavigator()
     {
         // Get SilverStripeNavigator links & stage info (CMS/Stage/Live/Archive)
         $nav = [];
@@ -136,7 +136,7 @@ class BetterNavigatorExtension extends DataExtension
      * Internally compute and cache weather the navigator should display
      * @return bool
      */
-    private function shouldDisplay(): bool
+    private function shouldDisplay()
     {
         if ($this->shouldDisplay !== null) {
             return $this->shouldDisplay;
@@ -157,7 +157,7 @@ class BetterNavigatorExtension extends DataExtension
     /**
      * @return boolean
      */
-    private function isAPage(): bool
+    private function isAPage()
     {
         return $this->owner
             && $this->owner->dataRecord

--- a/templates/BetterNavigator/BetterNavigator.ss
+++ b/templates/BetterNavigator/BetterNavigator.ss
@@ -3,19 +3,16 @@
 
 <div id="BetterNavigator" class="collapsed">
 
-    <% with $BetterNavigator %>
         <div id="BetterNavigatorStatus" class="$Viewing">
             <span class="bn-icon-cog"></span>
             $Viewing
             <span class="bn-icon-close"></span>
         </div>
-    <% end_with %>
 
     <div id="BetterNavigatorContent">
 
         <div class="bn-links">
 
-            <% with $BetterNavigator %>
                 <% if $ArchiveLink.Active %>
                     <% if $EditLink %><a href="$EditLink" target="_blank"><span class="bn-icon-edit"></span>Restore</a><% end_if %>
                 <% else %>
@@ -42,19 +39,18 @@
                 <% else %>
                     <a href="$LoginLink"><span class="bn-icon-user"></span>Log in</a>
                 <% end_if %>
-            <% end_with %>
 
         </div>
 
         <% include BetterNavigator\BetterNavigatorExtraContent %>
 
-        <% if $BetterNavigator.Mode=='dev' || $BetterNavigator.IsDeveloper %>
+        <% if $Mode=='dev' || $IsDeveloper %>
 
             <div class="bn-heading">Developer tools</div>
 
             <div class="bn-links">
 
-                <% if $BetterNavigator.Mode='dev' %>
+                <% if $Mode='dev' %>
                     <span class="bn-disabled" title="Log out to end Dev Mode"><span class="bn-icon-tick"></span>Dev mode on</span>
                 <% else %>
                     <a href="{$AbsoluteLink}?isDev=1"><span class="bn-icon-devmode"></span>Dev mode</a>

--- a/templates/BetterNavigator/BetterNavigator.ss
+++ b/templates/BetterNavigator/BetterNavigator.ss
@@ -1,6 +1,3 @@
-<% require javascript("jonom/silverstripe-betternavigator: javascript/betternavigator.js") %>
-<% require css("jonom/silverstripe-betternavigator: css/betternavigator.css") %>
-
 <div id="BetterNavigator" class="collapsed">
 
         <div id="BetterNavigatorStatus" class="$Viewing">


### PR DESCRIPTION
This pull request removes the need to add `$BetterNavigator` to your template, and injects the html directly into the HTTPResponse after the template is parsed.

This is somewhat API-breaking. The old `BetterNavigator()` method still returns `DBHTMLText`, but just empty, so ensure that users who upgrade don't get two navigators.

Have also upgraded the framework dependency to 4.2, as 4.0 and 4.1 are EOL.