### PR TITLE
Fix injection on Form posts

### DIFF
--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -50,6 +50,10 @@ class BetterNavigatorExtension extends DataExtension
             return $result;
         }
 
+        if (!($result instanceof DBHTMLText)) {
+            return $result;
+        }
+
         $html = $result->getValue();
         $navigatorHTML = $this->generateNavigator()->getValue();
 


### PR DESCRIPTION
In use with Silvershop, a form post from the AddProductForm would pass the form trough the `afterCallActionHandler` as the `$result`. This causes the `getValue` to error. By checking if the result is an instance of `DBHTMLText` this error can't happen anymore.