### PR TITLE
Adds ability to override "Edit in CMS" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ There may be occasions when you wish to override the "Edit in CMS" link. For exa
  */
 public function BetterNavigatorEditLink()
 {
-    return CMSEditLinkAPI::find_edit_link_for_object($this->displayedEvent());
+    $event = $this->displayedEvent();
+    return $event->canEdit() ? CMSEditLinkAPI::find_edit_link_for_object($event) : false;
 }
 ````
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ Some empty `<% include %>` placeholders are included to let you easily add more 
 
 The BetterNavigator.ss template's scope is set to the page that is being viewed, so any methods available in your page controller will be available in the BetterNavigator.ss template. This should allow you to add custom links by page type and introduce complex logic if you want to.
 
+## Overriding the "Edit in CMS" Link
+
+There may be occasions when you wish to override the "Edit in CMS" link. For example to point to the edit form for a displayed DataObject, rather than for the Page itself. To do so, simply add a `BetterNavigatorEditLink()` method to your page's Controller, e.g.:
+
+````php
+// EventsPageController.php
+
+/**
+ * Return an alternative URL for the BetterNavigator Edit in CMS link.
+ * @return string
+ */
+public function BetterNavigatorEditLink()
+{
+    return CMSEditLinkAPI::find_edit_link_for_object($this->displayedEvent());
+}
+````
+
+(This example uses [sunnysideup/cms_edit_link_field](https://github.com/sunnysideup/silverstripe-cms_edit_link_field) to automatically find an edit link for a specified DataObject, but you can return any URL.)
+
 ## Bonus: better debugging tools
 
 This module provide quick access to Silverstripe's built in [URL Variable Tools](http://doc.silverstripe.org/framework/en/reference/urlvariabletools) but reading their output isn't much fun. You can peek under Silverstripe's hood much more conveniently using lekoala's [Silverstripe DebugBar](https://github.com/lekoala/silverstripe-debugbar)

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -120,7 +120,7 @@ class BetterNavigatorExtension extends DataExtension
             } else {
                 // Only show edit link if user has permission to edit this page
                 $editLink = array_key_exists('CMSLink', $nav)
-                && ($this->owner->dataRecord->canEdit())
+                && ($isDev || $this->owner->dataRecord->canEdit())
                 ? $nav['CMSLink']['Link'] : false;
             }
         }

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -111,10 +111,19 @@ class BetterNavigatorExtension extends DataExtension
                 }
             }
         }
-        // Only show edit link if user has permission to edit this page
-        $editLink = array_key_exists('CMSLink', $nav)
-            && ($isDev || $this->owner->dataRecord->canEdit() && Permission::check('CMS_ACCESS_CMSMain'))
-            ? $nav['CMSLink']['Link'] : false;
+        
+        // Only show edit link if user has CMS access
+        if($isDev || Permission::check('CMS_ACCESS_CMSMain')) {
+            // Check for edit link override, e.g. for a DataObject
+            if(method_exists($this->owner, 'CustomBetterNavigatorEditLink')) {
+                $editLink = $this->owner->CustomBetterNavigatorEditLink();
+            } else {
+                // Only show edit link if user has permission to edit this page
+                $editLink = array_key_exists('CMSLink', $nav)
+                && ($this->owner->dataRecord->canEdit())
+                ? $nav['CMSLink']['Link'] : false;
+            }
+        }
 
         // Is the logged in member nominated as a developer?
         $member = Member::currentUser();

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -115,8 +115,8 @@ class BetterNavigatorExtension extends DataExtension
         // Only show edit link if user has CMS access
         if($isDev || Permission::check('CMS_ACCESS_CMSMain')) {
             // Check for edit link override, e.g. for a DataObject
-            if(method_exists($this->owner, 'CustomBetterNavigatorEditLink')) {
-                $editLink = $this->owner->CustomBetterNavigatorEditLink();
+            if(method_exists($this->owner, 'BetterNavigatorEditLink')) {
+                $editLink = $this->owner->BetterNavigatorEditLink();
             } else {
                 // Only show edit link if user has permission to edit this page
                 $editLink = array_key_exists('CMSLink', $nav)


### PR DESCRIPTION
Adds the ability to override the "Edit in CMS" link, e.g. to make it jump to editing a DataObject, instead of the page.

It checks for a `CustomBetterNavigatorEditLink()` method on the page and uses the value from it instead.

Fixes #54 

# Example
````php
// EventsPageController.php

public function CustomBetterNavigatorEditLink()
{
    return "https://mycustomeditlink.com";
}
````

Can be used with [sunnysideup/cms_edit_link_field](https://github.com/sunnysideup/silverstripe-cms_edit_link_field) to automatically find an edit link for a specific dataobject:

````php
// EventsPageController.php

public function CustomBetterNavigatorEditLink()
{
    return CMSEditLinkAPI::find_edit_link_for_object($this->myEvent());
}
````