### PR TITLE
Improved flexibility around whether better navigator should be displayed on a "page" or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The navigator is auto-injected into your template, and no code changes are neede
 
 If your website uses caching, make sure BetterNavigator's output is excluded.
 
-## Disabling the navigator
+## Custom navigator display logic
 
-You can disable the navigator using your own custom logic by defining a `showBetterNavigator(): bool`
-method in any controller with the extension applied.
+You can customise the navigator display logic using your own custom logic by defining a `showBetterNavigator(): bool`
+method in any controller with the extension applied. By default the navigator will only show on controllers that have a `dataRecord` property that is an instance of `SilverStripe\CMS\Model\SiteTree`.
 
 ```php
 public function showBetterNavigator()
@@ -100,25 +100,6 @@ public function BetterNavigatorEditLink()
 ````
 
 (This example uses [sunnysideup/cms_edit_link_field](https://github.com/sunnysideup/silverstripe-cms_edit_link_field) to automatically find an edit link for a specified DataObject, but you can return any URL.)
-
-## Overriding whether better navigator should be shown or not
-
-There may be occasions when you wish to override whether better navigator should be shown at all, for example on custom data objects. To do so simply add a `BetterNavigatorShouldDisplay()` method to your Controller, e.g.:
-```php
-// EventController.php
-
-/**
- * Detect whether better navigator should be displayed or not
- * @return bool
- */
-public function BetterNavigatorShouldDisplay()
-{
-    return $this->dataRecord
-        && $this->dataRecord instanceof Event
-        && $this->dataRecord->ID > 0
-        && (Director::isDev() || Permission::check('CMS_ACCESS_' . EventAdmin::class));
-}
-```
 
 ## Overriding the permissions required for the cms edit link
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,34 @@ public function BetterNavigatorEditLink()
 
 (This example uses [sunnysideup/cms_edit_link_field](https://github.com/sunnysideup/silverstripe-cms_edit_link_field) to automatically find an edit link for a specified DataObject, but you can return any URL.)
 
+## Overriding whether better navigator should be shown or not
+
+There may be occasions when you wish to override whether better navigator should be shown at all, for example on custom data objects. To do so simply add a `BetterNavigatorShouldDisplay()` method to your Controller, e.g.:
+```php
+// EventController.php
+
+/**
+ * Detect whether better navigator should be displayed or not
+ * @return bool
+ */
+public function BetterNavigatorShouldDisplay()
+{
+    return $this->dataRecord
+        && $this->dataRecord instanceof Event
+        && $this->dataRecord->ID > 0
+        && (Director::isDev() || Permission::check('CMS_ACCESS_' . EventAdmin::class));
+}
+```
+
+## Overriding the permissions required for the cms edit link
+
+By default users are required to have at least the `CMS_ACCESS_CMSMain` permission in order to see the edit link in better navigator, you can override this by setting the `better_navigator_edit_permission` configuration option on your controller to another permission code or an array of permission codes, e.g.:
+
+```yml
+My\Namespace\EventController:
+  better_navigator_edit_permission: "CUSTOM_PERMISSION_CODE"
+  better_navigator_edit_permission_mode: "any" #Optional, but can be either "any" or "all" (defaults to "all")
+
 ## Bonus: better debugging tools
 
 This module provide quick access to Silverstripe's built in [URL Variable Tools](http://doc.silverstripe.org/framework/en/reference/urlvariabletools) but reading their output isn't much fun. You can peek under Silverstripe's hood much more conveniently using lekoala's [Silverstripe DebugBar](https://github.com/lekoala/silverstripe-debugbar)

--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -66,7 +66,7 @@ class BetterNavigatorExtension extends DataExtension
      */
     public function showBetterNavigator()
     {
-        return true;
+        return $this->isAPage();
     }
 
     /**
@@ -165,14 +165,8 @@ class BetterNavigatorExtension extends DataExtension
             return $this->owner->getField('_betterNavigatorShouldDisplay');
         }
 
-        if ($this->owner->hasMethod('BetterNavigatorShouldDisplay')) {
-            $result = $this->owner->BetterNavigatorShouldDisplay();
-            $this->owner->setField('_betterNavigatorShouldDisplay', $result);
-            return $result;
-        }
-
         // Make sure this is a page
-        if (!$this->isAPage() || !$this->owner->showBetterNavigator()) {
+        if (!$this->owner->showBetterNavigator()) {
             $this->owner->setField('_betterNavigatorShouldDisplay', false);
             return false;
         }


### PR DESCRIPTION
This pull request is mainly focused around making it much easier to use better navigator on data objects rendered as pages that may have their own controller. It also replaces deprecated call to `Member::currentUser()` with `Security::getCurrentUser()`.

- Switched to using getField/setField for caching whether better navigator should be displayed or not, to avoid collisions when using nested controllers. For example passing routing to non-page children like an event calendar controller to event controller by actions on the event calendar controller. ([see here for the reason](https://docs.silverstripe.org/en/4/changelogs/4.0.0/#extensions-singletons))
- Moved the edit link permission code into the config layer so it can be overridden per-controller. This is good when (keeping with the event calendar theme) you have a model admin that controls events, and editing events requires a permission other than `CMS_ACCESS_CMSMain`. I've also added another permission code to allow overriding of the 2nd parameter to `Permission::check()` so that you can use "all" in the case of the permission codes being an array.
- Added a method (BetterNavigatorShouldDisplay) to allow overriding of the default shouldDisplay checks so that better navigator can be displayed on non-SiteTree decedent objects and with custom rule(s).