### PR TITLE
Fix Edit link not defined if no CMS access

### DIFF
--- a/src/Extension/BetterNavigatorExtension.php
+++ b/src/Extension/BetterNavigatorExtension.php
@@ -123,6 +123,8 @@ class BetterNavigatorExtension extends DataExtension
                 && ($isDev || $this->owner->dataRecord->canEdit())
                 ? $nav['CMSLink']['Link'] : false;
             }
+        }else{
+            $editLink = false;
         }
 
         // Is the logged in member nominated as a developer?


### PR DESCRIPTION
In the situation that a user has draft site access but no CMS access they received a '$editLink not defined error'. This corrects that be defining it as false.