### PR TITLE
Add Environment mode heading

### DIFF
--- a/templates/JonoM/BetterNavigator/BetterNavigator.ss
+++ b/templates/JonoM/BetterNavigator/BetterNavigator.ss
@@ -7,6 +7,7 @@
     </div>
 
     <div id="BetterNavigatorContent">
+        <div class="bn-heading"><%t JonoM\BetterNavigator.ENVIRONMENT 'Environment:' %> $Mode</div>
 
         <div class="bn-links">
 


### PR DESCRIPTION
Add an environment mode heading in the Navigator, to more clearly identify what environment the user is looking at.